### PR TITLE
Fix missing view on case sensitive file systems

### DIFF
--- a/handlers/Main.cfc
+++ b/handlers/Main.cfc
@@ -15,6 +15,7 @@ component extends="coldbox.system.EventHandler" {
 								task.lastResult.get() :
 								"";
 		});
+		event.setView( "main/index" );
 	}
 
 	function taskDelete( event, rc, prc ){


### PR DESCRIPTION
Auto discovery looks for `Main/index.cfm` but the view folder is called `main` so doesn't find the view on case sensitive file systems.